### PR TITLE
66-chore-use-repo-secrets-for-urls-in-pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '22'
+          node-version: '20'
 
       - name: Install Newman
         run: npm install -g newman

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,9 +67,9 @@ jobs:
 
       - name: Run Postman Collection
         env:
-          PERSONS_BASE_URL: ${{secrets.PERSONS_BASE_URL}}
-          PETS_BASE_URL: ${{secrets.PETS_BASE_URL}}
-          ACCOUNTS_BASE_URL: ${{secrets.ACCOUNTS_BASE_URL}}
+          PERSONS_BASE_URL: ${{ secrets.PERSONS_BASE_URL }}
+          PETS_BASE_URL: ${{ secrets.PETS_BASE_URL }}
+          ACCOUNTS_BASE_URL: ${{ secrets.ACCOUNTS_BASE_URL }}
         run: |
           newman run PurrgentCare.postman_collection.json --env-var "personsBaseURL=$PERSONS_BASE_URL" --env-var "petBaseURL=$PETS_BASE_URL" --env-var "accountBaseURL=$ACCOUNTS_BASE_URL"
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: ["main"]
+    branches: [ "main" ]
   pull_request:
-    branches: ["main"]
+    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -67,11 +67,11 @@ jobs:
 
       - name: Run Postman Collection
         env:
-          PERSONS_BASE_URL: http://localhost:8080/persons
-          PET_BASE_URL: http://localhost:8080/pets
-          ACCOUNT_BASE_URL: http://localhost:8080/accounts
+          PERSONS_BASE_URL: ${{secrets.PERSONS_BASE_URL}}
+          PETS_BASE_URL: ${{secrets.PETS_BASE_URL}}
+          ACCOUNTS_BASE_URL: ${{secrets.ACCOUNTS_BASE_URL}}
         run: |
-          newman run PurrgentCare.postman_collection.json --env-var "personsBaseURL=$PERSONS_BASE_URL" --env-var "petBaseURL=$PET_BASE_URL" --env-var "accountBaseURL=$ACCOUNT_BASE_URL"
+          newman run PurrgentCare.postman_collection.json --env-var "personsBaseURL=$PERSONS_BASE_URL" --env-var "petBaseURL=$PETS_BASE_URL" --env-var "accountBaseURL=$ACCOUNTS_BASE_URL"
 
       - name: Stop Spring Boot application
         run: kill $(cat spring-boot.pid)

--- a/documentation/github-secrets.md
+++ b/documentation/github-secrets.md
@@ -1,0 +1,38 @@
+# 🤫 GitHub Secrets
+
+___
+
+### Description
+
+[GitHub secrets][github-secrets-link] allow you to store sensitive information in your
+organization, repository, or repository environments.
+
+___
+
+### Adding a Secret to GitHub Repository
+
+To add a secret to a GitHub Repository follow these steps:
+
+1. On GitHub.com, navigate to the main page of the repository.
+2. Under your repository name, click Settings. If you cannot see the "Settings" tab,
+   select the dropdown menu, then click Settings.
+3. In the "Security" section of the sidebar, select Secrets and variables,
+   then click Actions.
+4. Click the Secrets tab.
+5. Click New repository secret.
+6. In the Name field, type a name for your secret.
+7. In the Secret field, enter the value for your secret.
+8. Click Add secret.
+
+---
+
+### Using Secrets in a Workflow
+
+See [GitHub Documentation][github-using-secrets-workflow-link]
+
+---
+
+
+[github-secrets-link]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions
+
+[github-using-secrets-workflow-link]:https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow

--- a/makefile
+++ b/makefile
@@ -31,7 +31,8 @@ start-backend:
 	make build-backend
 	mvn spring-boot:run
 
-test-backend-pipeline: compile-backend test-backend test-postman container-backend
+#TODO use docker to run application so we can run postman without needing two terminals
+test-backend-pipeline: compile-backend test-backend container-backend
 ## End Backend section
 
 ## Docker section


### PR DESCRIPTION
Replaced URL environment variables for newman in ci-cd.yml ; make test-backend-pipeline is failing